### PR TITLE
feat: load author from git config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "cargo-tag"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-tag"
-version = "0.1.1"
+version = "0.1.3"
 edition = "2021"
 
 license = "MIT"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,7 +2,6 @@ use cargo_tag::cli::Cli;
 use clap::Parser;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cli = Cli::parse();
-
-    cli.exec()
+    let Cli::Tag(args) = Cli::parse();
+    args.command.exec(args.env)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,6 @@
 use std::env::current_dir;
 
-use git2::{IndexAddOption, Repository, Signature, Tree};
+use git2::{Config, IndexAddOption, Repository, Signature, Tree};
 
 use crate::version::Version;
 
@@ -13,7 +13,7 @@ pub struct Git {
 }
 
 impl Git {
-    /// Creates `Git` client from environmesnt variables
+    /// Creates `Git` client from environment variables
     ///
     /// # Panics
     ///
@@ -23,6 +23,23 @@ impl Git {
         let name = std::env::var("CARGO_TAG_NAME").expect("CARGO_TAG_NAME not set");
 
         Git::open(branch, &email, &name).expect("Failed to open Git repository")
+    }
+
+    /// Creates `Git` client from git config
+    ///
+    /// # Panics
+    ///
+    /// If `user.email` or `user.name` are not found
+    pub fn from_git_config(branch: &str) -> Self {
+        let cfg = Config::open_default().expect("Cannot open git config");
+
+        let email = cfg.get_entry("user.email").expect("user.email not found");
+        let email = email.value().expect("user.email not utf8");
+
+        let name = cfg.get_entry("user.name").expect("user.name not found");
+        let name = name.value().expect("user.name not utf8");
+
+        Git::open(branch, email, name).expect("Failed to open Git repository")
     }
 
     /// Opens the Git repository in the current working directory and uses the


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

I made another branch with a separate `from_git_config` method and `--env` flag to decide whether or not to use it. I don't like it, but if you do, then merge this one instead of #50. I guess this closes #49, but compounds the problem with #48.