### PR TITLE
feat: add prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Cargo.toml and Cargo.lock files are updated with the new version, then a Git
 commit and a Git tag are both created.
 
 ```
-Usage: cargo-tag [COMMAND]
+Usage: cargo tag [OPTIONS] <COMMAND>
 
 Commands:
   current
@@ -41,11 +41,12 @@ Commands:
           Print this message or the help of the given subcommand(s)
 
 Options:
+  -p, --prefix <PREFIX>
+          Prefix string for Git tags
+      --env
+          Get name and email from environment variables CARGO_TAG_NAME and CARGO_TAG_EMAIL. They must be set beforehand.
   -h, --help
-          Print help information (use `-h` for a summary)
-
-  -V, --version
-          Print version information
+          Print help
 ```
 
 ## Installation
@@ -55,6 +56,13 @@ cargo install cargo-tag
 ```
 
 > Requires Git to be installed in your system.
+
+Using:
+```bash
+cargo tag patch
+# or
+cargo tag -p=v patch
+```
 
 ## Contributing
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,5 +3,5 @@ use clap::Parser;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let Cli::Tag(args) = Cli::parse();
-    args.command.exec(args.env)
+    args.command.exec(args.prefix.unwrap_or_default(), args.env)
 }

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -63,12 +63,12 @@ impl CargoToml {
         Ok(())
     }
 
-    /// Executes `cargo check`. This is useful after updating the version in
+    /// Executes `cargo fetch`. This is useful after updating the version in
     /// the `Cargo.toml` file to ensure `Cargo.lock` has the correct version.
-    pub fn run_cargo_check(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn run_cargo_fetch(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut cmd = Command::new("cargo");
 
-        cmd.arg("check");
+        cmd.arg("fetch");
         cmd.stderr(Stdio::inherit());
         cmd.status()?;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,8 +2,6 @@ use std::env::current_dir;
 
 use git2::{Config, IndexAddOption, Repository, Signature, Tree};
 
-use crate::version::Version;
-
 /// Performs Git related operations in the crate's repository
 pub struct Git {
     email: String,
@@ -77,13 +75,12 @@ impl Git {
     }
 
     /// Creates a Git Tag with the provided `Version`
-    pub fn tag(&self, version: &Version, message: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn tag(&self, version_str: &str, message: &str) -> Result<(), Box<dyn std::error::Error>> {
         let tagger = self.signature()?;
         let head = self.repo.head()?.peel_to_commit()?;
         let obj = head.as_object();
 
-        self.repo
-            .tag(&version.to_string(), obj, &tagger, message, false)?;
+        self.repo.tag(version_str, obj, &tagger, message, false)?;
 
         Ok(())
     }
@@ -102,8 +99,9 @@ impl Git {
 
         index.add_all(["*"].iter(), IndexAddOption::DEFAULT, None)?;
 
-        let tree = index.write_tree()?;
-        let tree = self.repo.find_tree(tree)?;
+        index.write()?;
+        let tree_id = index.write_tree()?;
+        let tree = self.repo.find_tree(tree_id)?;
 
         Ok(tree)
     }


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Please review #95 first.

With this option, we can do this to add a prefix to the tag:
```shell
cargo tag -p=v patch
```