### PR TITLE
fix: do not `panic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +68,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 name = "cargo-tag"
 version = "0.1.2"
 dependencies = [
+ "anyhow",
  "clap",
  "git2",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ description = "Cargo plugin to bump crate's versions and Git tag them for releas
 keywords = ["cargo", "tag", "git", "release"]
 categories = ["command-line-utilities", "development-tools"]
 include = ["src", "README.md"]
-homepage = "https://github.com/whizzes/cargo-tag"
-documentation = "https://github.com/whizzes/cargo-tag"
-repository = "https://github.com/whizzes/cargo-tag"
+homepage = "https://github.com/LeoBorai/cargo-tag"
+documentation = "https://github.com/LeoBorai/cargo-tag"
+repository = "https://github.com/LeoBorai/cargo-tag"
 readme = "README.md"
 
 [lib]
@@ -24,9 +24,10 @@ path = "src/bin/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.4.2", features = ["derive"] }
-git2 = { version = "0.20.0" }
-semver = { version = "1.0.17", features = ["serde"] }
-serde = { version = "1.0.188", features = ["derive"] }
+anyhow = "1"
+clap = { version = "4.5", features = ["derive"] }
+git2 = { version = "0.20" }
+semver = { version = "1.0", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
 toml = "0.9.8"
-toml_edit = "0.23.7"
+toml_edit = "0.23"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,9 @@
+use anyhow::Result;
+
 use cargo_tag::cli::Cli;
 use clap::Parser;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<()> {
     let Cli::Tag(args) = Cli::parse();
     args.command.exec(args.prefix.unwrap_or_default(), args.env)
 }

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
+use anyhow::Result;
 use semver::Version as SemVer;
 use serde::Deserialize;
 
@@ -48,7 +49,7 @@ impl CargoToml {
     }
 
     /// Update's current `Cargo.toml` version
-    pub fn write_version(&self, version: &Version) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn write_version(&self, version: &Version) -> Result<()> {
         let file_str = read_to_string(&self.meta.path)?;
         let mut document = file_str.parse::<toml_edit::DocumentMut>()?;
 
@@ -65,7 +66,7 @@ impl CargoToml {
 
     /// Executes `cargo fetch`. This is useful after updating the version in
     /// the `Cargo.toml` file to ensure `Cargo.lock` has the correct version.
-    pub fn run_cargo_fetch(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn run_cargo_fetch(&self) -> Result<()> {
         let mut cmd = Command::new("cargo");
 
         cmd.arg("fetch");


### PR DESCRIPTION
This pull request refactors error handling across the codebase to consistently use the `anyhow::Result` type instead of boxed errors, improving error propagation and simplifying function signatures. It also updates dependency versions and changes project metadata to reflect a new repository location.

**Error handling improvements:**

* Refactored all functions in `src/git.rs`, `src/cargo_toml.rs`, and `src/cli.rs` to return `anyhow::Result` instead of `Result<_, Box<dyn std::error::Error>>`, standardizing error handling and making code easier to read and maintain. [[1]](diffhunk://#diff-b11d55da9b9142c8779f55b1a2a4588a2de8f52ef0667e55a0d24b76c4e57515L51-R52) [[2]](diffhunk://#diff-b11d55da9b9142c8779f55b1a2a4588a2de8f52ef0667e55a0d24b76c4e57515L68-R69) [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR1) [[4]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL53-R68) [[5]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L19-R47) [[6]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L60-R61) [[7]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L78-R79) [[8]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L90-R98)
* Enhanced error messages in `src/cli.rs` for opening `Cargo.toml` and creating `Git` clients, providing clearer context when failures occur.

**Dependency updates:**

* Updated versions for dependencies in `Cargo.toml`, including `clap`, `git2`, `semver`, `serde`, and `toml_edit`, ensuring compatibility and access to recent features.

**Project metadata changes:**

* Changed `homepage`, `documentation`, and `repository` fields in `Cargo.toml` to point to `https://github.com/LeoBorai/cargo-tag`, reflecting a migration to a new repository owner.

**CLI improvements:**

* Added a more descriptive help message for the `Tag` subcommand in the CLI, clarifying its purpose for users.