### PR TITLE
feat: print resulting version

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,8 @@ impl Command {
 
                 repository.commit(&format!("chore: bump version to {}", version_str))?;
                 repository.tag(&version_str, "chore: bump version to {}")?;
+
+                println!("{version_str}")
             }
         }
 


### PR DESCRIPTION
This pull request introduces a minor update to the version bump workflow in the CLI. Now, after bumping the version and tagging the commit, the new version string is printed to the console for easier visibility.

* After committing and tagging the new version, the CLI prints the `version_str` to standard output for user feedback.