### PR TITLE
feat(cd): use `cargo tag` in place of `cargo edit`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,11 @@ jobs:
         run: |
           cargo binstall -y --force cargo-tag
 
-      - name: Set Version
-        run: echo "CRATE_VERSION=$(cargo tag -p=v ${{ inputs.version }})" >> $GITHUB_ENV
-
-      - name: Push Commit & Tags
+      - name: Bump Version
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          echo "CRATE_VERSION=$(cargo tag -p=v ${{ inputs.version }})" >> $GITHUB_ENV
           git push origin main --follow-tags
 
       - uses: rust-lang/crates-io-auth-action@v1


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yml` to streamline version management and improve the release process. The main changes involve switching from `cargo-edit` to `cargo-tag` for versioning, simplifying how the crate version is set as an environment variable, and updating release commit and title formatting.

**Versioning and Release Process Improvements:**

* Replaced installation of `cargo-edit` with `cargo-tag` and updated version bumping to use `cargo tag -p v ${{ inputs.version }}` instead of `cargo set-version`, simplifying version management in the workflow.
* Removed manual extraction of the crate version from `Cargo.toml` using `awk` and now sets the `CRATE_VERSION` environment variable directly from the output of `cargo tag`.

**Release Commit and Title Formatting:**

* Updated the commit message to use the new version format without the leading `v`, and adjusted the release creation step to use the new `CRATE_VERSION` variable for the release title, ensuring consistency in version naming. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L51-R61) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L81-R75)