### PR TITLE
feat: support pre-release creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "cargo-tag"
-version = "0.1.6-alpha12345"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-tag"
-version = "0.1.6-alpha12345"
+version = "0.1.6"
 edition = "2021"
 
 license = "MIT"


### PR DESCRIPTION
This pull request introduces support for prerelease versioning in the `cargo-tag` tool. The main changes add a new command to set a prerelease string, update the version in `Cargo.toml`, and create a corresponding git tag. Additionally, the version in the manifest is updated to reflect an alpha prerelease.

**Prerelease versioning support:**

* Added a new `PreRelease { prerelease: String }` variant to the `Command` enum in `src/cli.rs`, allowing users to specify a prerelease string for versioning.
* Implemented handling for the `PreRelease` command in `impl Command` in `src/cli.rs`, which updates the version with the given prerelease, writes it to `Cargo.toml`, commits the change, and creates a git tag.
* Added a `set_prerelease` method to the `Version` struct in `src/version.rs` to safely set the prerelease component of a version using the `semver` crate.

**Dependency and error handling improvements:**

* Added imports for `anyhow` error handling in `src/version.rs` to support robust error reporting in the new `set_prerelease` method.