### PR TITLE
fix(git): support branch discovery

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,3 @@
-use std::env::current_dir;
-
 use anyhow::{Context, Result};
 use git2::{Config, IndexAddOption, Repository, Signature, Tree};
 
@@ -45,8 +43,7 @@ impl Git {
     /// provided `email`, `name` and `branch` to perform Git operations like
     /// `commit` and `tag`.
     pub fn open(branch: &str, email: &str, name: &str) -> Result<Self> {
-        let cwd = current_dir()?;
-        let repo = Repository::open(cwd)?;
+        let repo = Repository::open_from_env()?;
 
         Ok(Self {
             email: email.into(),


### PR DESCRIPTION
This pull request makes a small change to how the repository is opened in the `Git` implementation. Instead of using the current working directory, it now uses `Repository::open_from_env()`, which is more robust and respects environment variables for repository discovery.

* Replaced usage of `current_dir()` and `Repository::open(cwd)` with `Repository::open_from_env()` in the `Git::open` method for improved repository discovery.
* Removed the unnecessary import of `current_dir` from `std::env`.